### PR TITLE
refactor: Add type guard for logger strategy getId method

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,11 @@ export class LoggerStrategy<
   ) {
     this.logStrategies = injectors.filter(logger => logger.enabled).map(logger => logger.class)
     this.strategyMap = new Map(
-      this.logStrategies.map(strategy => [strategy.getId(), strategy])
+      this.logStrategies
+        .filter((strategy): strategy is LoggerStrategyType<TLogTags, TNetworkTags, TUser, TBeginCheckout, TPurchase, TEvent> & { getId: () => string } => 
+          typeof strategy.getId === 'function'
+        )
+        .map(strategy => [strategy.getId(), strategy])
     )
   }
 


### PR DESCRIPTION
- Enhance type safety for logger strategy initialization
- Filter strategies with valid getId method before creating strategy map
- Prevent potential runtime errors with type-safe strategy selection
