### PR TITLE
feat/log-levels: implemented log levels

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ A TypeScript-based universal logging solution that provides consistent logging a
     - [Creating a Custom Logger](#creating-a-custom-logger)
     - [Using the Custom Logger](#using-the-custom-logger)
   - [Advanced Features](#advanced-features)
+    - [Log Levels](#log-levels)
     - [User Tracking](#user-tracking)
     - [Screen Tracking](#screen-tracking)
     - [Error Handling](#error-handling)
@@ -325,6 +326,34 @@ logger.flush();
 ```
 
 ## Advanced Features
+
+### Log Levels
+
+The logger supports different log levels to control the verbosity of logging:
+
+```typescript
+// Set minimum log level (default is 'info')
+logger.setMinLogLevel('debug');
+
+// Available log levels (in order of severity):
+// - debug: Detailed information for debugging
+// - info: General operational information
+// - warn: Warning messages for potentially harmful situations
+// - error: Error events that might still allow the application to continue
+// - fatal: Very severe error events that will presumably lead to application failure
+
+// Logging with different levels
+logger.debug('Auth', 'User session expired', { userId: '123' });
+logger.info('Auth', 'User logged in', { userId: '123' });
+logger.warn('Auth', 'Multiple failed login attempts', { userId: '123' });
+logger.error('Auth', 'Login failed', false, new Error('Invalid credentials'));
+logger.fatal('Auth', 'Database connection failed', new Error('Connection timeout'));
+
+// You can also specify log level in options for any logging method
+logger.log('custom_event', { data: 'value' }, { level: 'debug' });
+logger.event('user-action', { action: 'click' }, { level: 'info' });
+logger.network('api-call', { endpoint: '/users' }, { level: 'warn' });
+```
 
 ### User Tracking
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -64,6 +64,14 @@ export interface PaymentData extends CheckoutData {
   type: string;
 }
 
+export type LogLevel = 'debug' | 'info' | 'warn' | 'error' | 'fatal';
+
+export interface LogOptions {
+  level?: LogLevel;
+  timestamp?: boolean;
+  [key: string]: any;
+}
+
 export interface LoggerStrategyConstructor<
   TLogTags extends string = LOG_TAGS,
   TNetworkTags extends string = NETWORK_ANALYTICS_TAGS,
@@ -88,12 +96,12 @@ export abstract class LoggerStrategyType<
 	TEvent extends Record<string, any> = EVENT_TAGS
 > {
 	abstract init(): void
-	abstract log?(name: TLogTags, properties?: Record<string, any>): void
-	abstract event?<T extends keyof TEvent>(name: T, properties?: TEvent[T]): void
-	abstract network?(name: TNetworkTags, properties?: Record<string, any>): void
+	abstract log?(name: TLogTags, properties?: Record<string, any>, options?: LogOptions): void
+	abstract event?<T extends keyof TEvent>(name: T, properties?: TEvent[T], options?: LogOptions): void
+	abstract network?(name: TNetworkTags, properties?: Record<string, any>, options?: LogOptions): void
 
-	abstract info?(feature: string, name: string, properties?: Record<string, any> | string | boolean): void
-	abstract error?(feature: string, name: string, critical: boolean, error: Error, extra?: Record<string, unknown>): void
+	abstract info?(feature: string, name: string, properties?: Record<string, any> | string | boolean, options?: LogOptions): void
+	abstract error?(feature: string, name: string, critical: boolean, error: Error, extra?: Record<string, unknown>, options?: LogOptions): void
 
 	abstract reset?(): void
 	abstract logScreen?(screenName: string, params?: Record<string, any>): void


### PR DESCRIPTION
Implemeted different log levels to control logging verbosity and categorize log messages.

## Summary by Sourcery

Implement log level support in the LoggerStrategy, allowing users to set a minimum log level, filter messages accordingly, and use new debug, warn, and fatal methods.

New Features:
- Add configurable log levels with setMinLogLevel and per-message verbosity control
- Introduce debug, warn, and fatal logging methods

Enhancements:
- Extend existing log, event, info, network, and error methods to accept LogOptions and perform level-based filtering
- Introduce internal shouldLog method with default minimum level 'info'
- Update type definitions to include LogLevel and LogOptions

Documentation:
- Add Log Levels section to README with usage examples